### PR TITLE
copy & paste error. 2014->2015

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 This is the Open Data Index as published for the 2015 release.
 
-* The 2014 site is hosted here: http://2015.index.okfn.org/
+The 2015 site is hosted here: http://2015.index.okfn.org/
 
 This repository is closed to contributions. See the Open Data Index [code repository here](https://github.com/okfn/opendataindex) for issues and contributions.


### PR DESCRIPTION
Pretty sure that should say 2015 (i.e. it's a link to the website of *this* repo).  Also no need to be a bullet point